### PR TITLE
Live avering over all NTCs

### DIFF
--- a/Fresco_TD_PC_V2/Fresco_TD_PC_V2.ino
+++ b/Fresco_TD_PC_V2/Fresco_TD_PC_V2.ino
@@ -1300,6 +1300,17 @@ void drawLIP() {
   } while (u8g.nextPage());
 }
 
+void drawBETA() {
+  u8g.firstPage();
+  do {
+    draw();
+    u8g.setFont(u8g_font_8x13);
+    u8g.setPrintPos(3, 30);
+    u8g.print("NTC Beta value");
+    u8g.setPrintPos(10, 50);
+    u8g.print(B);
+  } while (u8g.nextPage());
+}
 void Draw_dateandtime() {
   u8g.firstPage();
   do {
@@ -1590,6 +1601,10 @@ void init_screen() {
   startTime = millis();  // Reset the start time
   while (millis() - startTime < 2000) {
     drawLIP();
+  }
+  startTime = millis();  // Reset the start time
+  while (millis() - startTime < 2000) {
+    drawBETA();
   }
   u8g.firstPage();  // first page
   do {

--- a/Fresco_TD_PC_V2/Fresco_TD_PC_V2.ino
+++ b/Fresco_TD_PC_V2/Fresco_TD_PC_V2.ino
@@ -450,7 +450,7 @@ bool SendCurrentChannel(unsigned char channel) {
 #ifdef __SEND_POWER_DENSITY__
   Serial.print(">PowerDensity(");
   Serial.print(channel);
-  Serial.print(")[W/mq]:");
+  Serial.print(")[W/m2]:");
   Serial.println(powerDensity[channel], 2);
 #endif
 #endif


### PR DESCRIPTION
Live averaging (measurement every 10 ms and average every sec) is done for all the NTCs (not only for Pcool NTCs as before). This significantly reduce the noise on the Tdrop measurement. 

Additionally, the set beta value is displayed on the monitor at the FRESCO startup.