### PR TITLE
Fix Pcool units

### DIFF
--- a/Fresco_TD_PC_V2/Fresco_TD_PC_V2.ino
+++ b/Fresco_TD_PC_V2/Fresco_TD_PC_V2.ino
@@ -144,13 +144,13 @@ PID heaterController[ANALOG_CHANNELS] = {
 
 
 /*---------*/
-double currentCalibration = 1000 * PSUPPLY_VOLTAGE * R_SHUNT / (R_SHUNT + R_LOAD);
+double currentCalibration = 1000 * PSUPPLY_VOLTAGE * R_SHUNT / (R_SHUNT + R_LOAD); // tension at R_SHUNT
 //double POWER_DENSITY_FACTOR = 1000 * (float)PSUPPLY_VOLTAGE * (R_LOAD / (R_SHUNT + R_LOAD)) / SAMPLE_SURFACE;
 int count = 0;
 long temperatureCounter = 0;
 long temperatureCounterNTC = 0;
 long currentCounter = 0;
-
+double Imax_R_LOAD = PSUPPLY_VOLTAGE * R_LOAD / (R_SHUNT + R_LOAD); // max current initialization* R_LOAD
 double currentValue[ANALOG_CHANNELS] = { 0, 0, 0, 0 };
 double currentCalibrationValue[ANALOG_CHANNELS] = { 0, 0, 0, 0 };
 double powerDensity[ANALOG_CHANNELS] = { 0, 0, 0, 0 };
@@ -528,11 +528,11 @@ bool GetCurrentChannel(unsigned char channel) {
 bool SendCurrentChannel(unsigned char channel) {
 
   currentValue[channel] /= currentCounter;
-  currentValue[channel] *= currentCalibration;
-  currentValue[channel] /= currentCalibrationValue[channel];
+  currentValue[channel] *= currentCalibration;// *V_LOAD
+  currentValue[channel] /= currentCalibrationValue[channel]; // maximum current value during the initialization (ADC)
 
   powerDensity[channel] = currentValue[channel] / 1000;
-  powerDensity[channel] *= PSUPPLY_VOLTAGE;
+  powerDensity[channel] *= Imax_R_LOAD; // Maximum current value during the initialization* R_LOAD
   powerDensity[channel] /= SAMPLE_SURFACE;
 
 #ifdef __TELEPLOT_ENABLED__

--- a/Fresco_TD_PC_V2/Fresco_TD_PC_V2.ino
+++ b/Fresco_TD_PC_V2/Fresco_TD_PC_V2.ino
@@ -1433,7 +1433,7 @@ void Draw_tBxtBr() {
     u8g.setPrintPos(3, 30);
     u8g.print("TBox and Board");
     u8g.setPrintPos(5, 40);
-    u8g.print(T[4], 2);
+    u8g.print(averageTemperatureNTCValue[4], 2);
     u8g.setPrintPos(65, 40);
     u8g.print("C");
     u8g.setPrintPos(10, 60);


### PR DESCRIPTION
Take into account R_LOAD / (R_LOAD + R_SHUNT) factor in Pcool value.

Additionally, add Tbox fast averaging on the OLED display.